### PR TITLE
Add tolowercase feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,11 +52,22 @@ jobs:
       - attach_workspace: *attach_workspace
       - run: bin/phpcs seo-routing/Classes
 
+  unit-tests:
+    working_directory: *workspace_root
+    docker:
+      - image: *ci-build-image
+    steps:
+      - attach_workspace: *attach_workspace
+      - run: bin/phpunit -c unitTests.xml
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - checkout
       - lint:
+          requires:
+            - checkout
+      - unit-tests:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           shopt -u dotglob
           cp seo-routing/composer.json.ci composer.json
           cp seo-routing/phpcs.xml.dist phpcs.xml.dist
+          cp seo-routing/unitTests.xml unitTests.xml
           composer update
       - save_cache: *save_composer_cache
       - persist_to_workspace: *persist_to_workspace
@@ -52,11 +53,22 @@ jobs:
       - attach_workspace: *attach_workspace
       - run: bin/phpcs seo-routing/Classes
 
+  unit-tests:
+    working_directory: *workspace_root
+    docker:
+      - image: *ci-build-image
+    steps:
+      - attach_workspace: *attach_workspace
+      - run: bin/phpunit -c unitTests.xml
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - checkout
       - lint:
+          requires:
+            - checkout
+      - unit-tests:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           shopt -u dotglob
           cp seo-routing/composer.json.ci composer.json
           cp seo-routing/phpcs.xml.dist phpcs.xml.dist
+          cp seo-routing/unitTests.xml unitTests.xml
           composer update
       - save_cache: *save_composer_cache
       - persist_to_workspace: *persist_to_workspace

--- a/Classes/BlacklistTrait.php
+++ b/Classes/BlacklistTrait.php
@@ -28,6 +28,10 @@ trait BlacklistTrait
 
     protected function matchesBlacklist(UriInterface $uri): bool
     {
+        if (! is_array($this->blacklist)) {
+            return false;
+        }
+
         $path = $uri->getPath();
         foreach ($this->blacklist as $rawPattern => $active) {
             $pattern = '/' . str_replace('/', '\/', $rawPattern) . '/';

--- a/Classes/BlacklistTrait.php
+++ b/Classes/BlacklistTrait.php
@@ -28,6 +28,10 @@ trait BlacklistTrait
 
     protected function matchesBlacklist(UriInterface $uri): bool
     {
+        if (!is_array($this->blacklist)) {
+            return false;
+        }
+
         $path = $uri->getPath();
         foreach ($this->blacklist as $rawPattern => $active) {
             $pattern = '/' . str_replace('/', '\/', $rawPattern) . '/';

--- a/Classes/BlacklistTrait.php
+++ b/Classes/BlacklistTrait.php
@@ -28,7 +28,7 @@ trait BlacklistTrait
 
     protected function matchesBlacklist(UriInterface $uri): bool
     {
-        if (!is_array($this->blacklist)) {
+        if (! is_array($this->blacklist)) {
             return false;
         }
 

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -101,7 +101,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         return $uri;
     }
 
-    protected function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath)
+    protected function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath): void
     {
         if ($uri->getPath() === $oldPath) {
             return;

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -41,6 +41,15 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
      */
     protected $configuration;
 
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+
+        if (! is_array($this->configuration)) {
+            $this->configuration = [];
+        }
+    }
+
     /**
      * Redirect automatically to the trailing slash url or lowered url if activated
      */
@@ -89,16 +98,22 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         return $uri;
     }
 
-    protected function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath): void
+    public function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath): bool
     {
         if ($uri->getPath() === $oldPath) {
-            return;
+            return false;
         }
 
+        //set default redirect statusCode if configuration is not set
+        $statusCode = array_key_exists('statusCode', $this->configuration) ? $this->configuration['statusCode'] : 301;
+
         $response = $componentContext->getHttpResponse();
-        $response->setStatus($this->configuration['statusCode']);
-        $response->setHeader('Location', (string) $uri);
+        $response->withStatus((int) $statusCode);
+        $response->withHeader('Location', (string) $uri);
 
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);
+
+        return true;
     }
+
 }

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -85,7 +85,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         }
     }
 
-    protected function redirectToUri(ComponentContext $componentContext, string $uri): void
+    protected function redirectToUri(ComponentContext $componentContext, UriInterface $uri): void
     {
         $response = $componentContext->getHttpResponse();
         $response->setStatus($this->configuration['statusCode']);

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -69,7 +69,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
             return;
         }
 
-        if ($this->matchesBlacklist($uri) === false && isset(pathinfo($uri)['extension']) === false) {
+        if ($this->matchesBlacklist($uri) === false) {
             $uri->setPath($path . '/');
             $this->redirectToUri($componentContext, $uri);
         }

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -55,7 +55,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
      */
     public function handle(ComponentContext $componentContext): void
     {
-        $trailingSlashIsEnabled = isset($this->configuration['enable']['trailingSlash']) ? $this->configuration['enable']['trailingSlash'] === true : true;
+        $trailingSlashIsEnabled = isset($this->configuration['enable']['trailingSlash']) ? $this->configuration['enable']['trailingSlash'] === true : false;
         $toLowerCaseIsEnabled = isset($this->configuration['enable']['toLowerCase']) ? $this->configuration['enable']['toLowerCase'] === true : false;
 
         $uri = $componentContext->getHttpRequest()->getUri();

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -17,10 +17,7 @@ namespace t3n\SEO\Routing;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
-use Neos\Flow\Http\Response;
-use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\Routing\RouterInterface;
-use Psr\Http\Message\UriInterface;
 
 class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
 {
@@ -45,14 +42,11 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
 
     /**
      * Redirect automatically to the trailing slash url or lowered url if activated
-     *
-     * @param ComponentContext $componentContext
      */
     public function handle(ComponentContext $componentContext): void
     {
-        $isEnabled = $this->configuration['enable'];
+        $isEnabled = $this->configuration['enable'] === true;
 
-        /** @var Uri $uri */
         $uri = $componentContext->getHttpRequest()->getUri();
         $path = $uri->getPath();
 
@@ -66,7 +60,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
 
         $loweredPath = strtolower($path);
 
-        if ($isEnabled && $this->configuration['toLowerCase'] && $path !== $loweredPath) {
+        if ($isEnabled && $this->configuration['toLowerCase'] === true && $path !== $loweredPath) {
             $uri->setPath($loweredPath);
             $this->redirectToUri($componentContext, $uri);
             return;

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -41,6 +41,9 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
      */
     protected $configuration;
 
+    /**
+     * @param mixed[] $options
+     */
     public function __construct(array $options = [])
     {
         parent::__construct($options);
@@ -115,5 +118,4 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
 
         return true;
     }
-
 }

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -101,10 +101,10 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         return $uri;
     }
 
-    public function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath): bool
+    protected function redirectIfNecessary(ComponentContext $componentContext, UriInterface $uri, string $oldPath)
     {
         if ($uri->getPath() === $oldPath) {
-            return false;
+            return;
         }
 
         //set default redirect statusCode if configuration is not set
@@ -116,6 +116,6 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
 
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);
 
-        return true;
+        return;
     }
 }

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -71,7 +71,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
             return $uri;
         }
 
-        if ($this->matchesBlacklist($uri) === false && !array_key_exists('extension', pathinfo($uri->getPath()))) {
+        if ($this->matchesBlacklist($uri) === false && ! array_key_exists('extension', pathinfo($uri->getPath()))) {
             $uri->setPath($uri->getPath() . '/');
         }
 

--- a/Configuration/NodeTypes.Document.yaml
+++ b/Configuration/NodeTypes.Document.yaml
@@ -1,0 +1,6 @@
+'Neos.Neos:Document':
+  properties:
+    uriPathSegment:
+      validation:
+        'Neos.Neos/Validation/RegularExpressionValidator':
+          regularExpression: '/^[a-z0-9\-]+$' #override original regex (removes insensitive)

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,9 +2,10 @@ t3n:
   SEO:
     Routing:
       redirect:
-        enable: true
-        statusCode: 303
-        toLowerCase: false
+        enable:
+          trailingSlash: true
+          toLowerCase: false
+        statusCode: 301
       blacklist:
         '/neos/.*': true
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,7 @@ t3n:
       redirect:
         enable: true
         statusCode: 303
+        toLowerCase: false
       blacklist:
         '/neos/.*': true
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,52 @@
 [![CircleCI](https://circleci.com/gh/t3n/seo-routing.svg?style=svg)](https://circleci.com/gh/t3n/seo-routing) [![Latest Stable Version](https://poser.pugx.org/t3n/seo-routing/v/stable)](https://packagist.org/packages/t3n/seo-routing) [![Total Downloads](https://poser.pugx.org/t3n/seo-routing/downloads)](https://packagist.org/packages/t3n/seo-routing) [![License](https://poser.pugx.org/t3n/seo-routing/license)](https://packagist.org/packages/t3n/seo-routing)
 
 # t3n.SEO.Routing
-Package to ensure that all links end with a trailing slash, e.g. `example.com/test/` instead of `example.com/test.
+
+This package has 2 main features:
+- **trailingSlash**: ensure that all links ends with a trailing slash (e.g. `example.com/test/ instead of `example.com/test)
+- **toLowerCase**: ensure that camelCase links gets redirected to lowercase (e.g. `exmaple.com/lowercase` instead of `exmaple.com/lowerCase` )
+
+You can de- and activate both of them.
+
+Another small feature is to restrict all _new_ neos pages to have a lowercased `uriPathSegment`. This is done by extending the `NodeTypes.Document.yaml`.
+
+## Installation
+
+Just require it via composer:`
+
+```composer require t3n/seo-routing```
 
 ## Configuration
 
-By default, all `/neos/` URLs are ignored. You can extend the blacklist array with regex as you like.
+### Standard Configuration
+
+In the standard configuration we have activated the trailingSlash (to redirect all uris without a / at the and to an uri with / at the end) and do all redirects with a 301 http status.
+
+*Note: The lowercase redirect is deactivated by default, cause you have to make sure, that there is no `uriPathSegment`  with camelCase or upperspace letters - this would lead to redirects in the neverland.* 
+
+```
+t3n:
+  SEO:
+    Routing:
+      redirect:
+        enable:
+          trailingSlash: true
+          toLowerCase: false
+        statusCode: 301
+      blacklist:
+        '/neos/.*': true
+```
+
+### Blacklist for redirects
+
+By default, all `/neos/` URLs are ignored for redirects. You can extend the blacklist array with regex as you like:
 
 ```yaml
 t3n:
   SEO:
     Routing:
-      redirect:
-        enable: true
-        statusCode: 303
+      #redirect:
+        #...
       blacklist:
         '/neos/.*': true
 ```

--- a/Tests/Unit/RoutingComponentTest.php
+++ b/Tests/Unit/RoutingComponentTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace t3n\SEO\Routing\Tests\Unit;
+
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Request;
+use Neos\Flow\Http\Response;
+use Neos\Flow\Http\Uri;
+use Neos\Flow\Mvc\Routing\Router;
+use Neos\Flow\Tests\UnitTestCase;
+use t3n\SEO\Routing\RoutingComponent;
+
+class RoutingComponentTest extends UnitTestCase
+{
+    /**
+     * @return mixed[]
+     */
+    public function invalidUrisWithConfig(): array
+    {
+        // invalidUrl, validUrl, trailingSlash, toLowerCase
+        return [
+            ['http://dev.local/invalid', 'http://dev.local/invalid/', true, false],
+            ['http://dev.local/invalId', 'http://dev.local/invalid/', true, true],
+            ['http://dev.local/invalId/', 'http://dev.local/invalid/', false, true]
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithSlashGetsNotModifiedForTrailingSlash(): void
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath/');
+        $newUri = $routingComponent->handleTrailingSlash($uri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithOutSlashGetsModifiedForTrailingSlash(): void
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath');
+        $newUri = $routingComponent->handleTrailingSlash($uri);
+
+        $this->assertStringEndsWith('/', (string) $newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithLoweredPathGetsNotModified(): void
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath/');
+        $newUri = $routingComponent->handleToLowerCase($uri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithCamelCasePathGetsModifiedToLowereCase(): void
+    {
+        $routingComponent = new RoutingComponent();
+
+        $camelCasePath = '/testPath/';
+        $uri = new Uri('http://dev.local' . $camelCasePath);
+        $newUri = $routingComponent->handleToLowerCase($uri);
+
+        $this->assertNotEquals($camelCasePath, $newUri->getPath());
+        $this->assertEquals(strtolower($camelCasePath), $newUri->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithSpecialCharsDoesNotThrowAnException(): void
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/äß&/');
+        $newUri = $routingComponent->handleToLowerCase($uri);
+        $newUri = $routingComponent->handleTrailingSlash($newUri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidUrisWithConfig
+     */
+    public function ifPathHasChangesRedirect(string $invalidUrl, string $validUrl, bool $trailingSlash, bool $toLowerCase): void
+    {
+        $configuration = [
+            'enable' => [
+                'trailingSlash' => $trailingSlash,
+                'toLowerCase' => $toLowerCase
+            ],
+        ];
+
+
+        $httpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['getUri', 'withStatus'])->getMock();
+        $httpRequest->method('getUri')->willReturn(new Uri($invalidUrl));
+
+        $httpResponse = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->setMethods(['withStatus', 'withHeader'])->getMock();
+        $httpResponse->expects($this->once())->method('withStatus')->with(301);
+        $httpResponse->expects($this->once())->method('withHeader')->with('Location', $validUrl);
+
+        /** @var ComponentContext $componentContext */
+        $componentContext = $this->getMockBuilder(ComponentContext::class)->disableOriginalConstructor()->setMethods(['getHttpRequest', 'getHttpResponse'])->getMock();
+        $componentContext->method('getHttpRequest')->willReturn($httpRequest);
+        $componentContext->method('getHttpResponse')->willReturn($httpResponse);
+
+        $routerMock = $this->getMockBuilder(Router::class)->disableOriginalConstructor()->setMethods(['route'])->getMock();
+        $routerMock->method('route')->willReturn([]);
+
+        $routingComponent = new RoutingComponent();
+
+        $this->inject($routingComponent, 'router', $routerMock);
+        $this->inject($routingComponent, 'configuration', $configuration);
+
+        $routingComponent->handle($componentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function ifPathHasNoChangesDoNotRedirect(): void
+    {
+        $configuration = [
+            'enable' => [
+                'trailingSlash' => true,
+                'toLowerCase' => true
+            ],
+        ];
+
+        $validPath = 'http://dev.local/validpath/';
+
+        $httpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->setMethods(['getUri', 'withStatus'])->getMock();
+        $httpRequest->method('getUri')->willReturn(new Uri($validPath));
+
+        $httpResponse = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->setMethods(['withStatus', 'withHeader'])->getMock();
+        $httpResponse->expects($this->never())->method('withStatus');
+        $httpResponse->expects($this->never())->method('withHeader');
+
+        /** @var ComponentContext $componentContext */
+        $componentContext = $this->getMockBuilder(ComponentContext::class)->disableOriginalConstructor()->setMethods(['getHttpRequest', 'getHttpResponse'])->getMock();
+        $componentContext->method('getHttpRequest')->willReturn($httpRequest);
+        $componentContext->method('getHttpResponse')->willReturn($httpResponse);
+
+        $routerMock = $this->getMockBuilder(Router::class)->disableOriginalConstructor()->setMethods(['route'])->getMock();
+        $routerMock->method('route')->willReturn([]);
+
+        $routingComponent = new RoutingComponent();
+
+        $this->inject($routingComponent, 'router', $routerMock);
+        $this->inject($routingComponent, 'configuration', $configuration);
+
+        $routingComponent->handle($componentContext);
+    }
+}

--- a/Tests/Unit/RoutingComponentTest.php
+++ b/Tests/Unit/RoutingComponentTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace t3n\SEO\Routing\Tests\Unit;
 
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Request;
+use Neos\Flow\Http\Response;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Tests\UnitTestCase;
 use t3n\SEO\Routing\RoutingComponent;
@@ -18,7 +21,7 @@ class RoutingComponentTest extends UnitTestCase
     {
         $routingComponent = new RoutingComponent();
 
-        $uri = new Uri('http://dev.local/testpath/');
+        $uri    = new Uri('http://dev.local/testpath/');
         $newUri = $routingComponent->handleTrailingSlash($uri);
 
         $this->assertEquals($uri, $newUri);
@@ -31,7 +34,7 @@ class RoutingComponentTest extends UnitTestCase
     {
         $routingComponent = new RoutingComponent();
 
-        $uri = new Uri('http://dev.local/testpath');
+        $uri    = new Uri('http://dev.local/testpath');
         $newUri = $routingComponent->handleTrailingSlash($uri);
 
         $this->assertStringEndsWith('/', (string)$newUri);
@@ -44,7 +47,7 @@ class RoutingComponentTest extends UnitTestCase
     {
         $routingComponent = new RoutingComponent();
 
-        $uri = new Uri('http://dev.local/testpath/');
+        $uri    = new Uri('http://dev.local/testpath/');
         $newUri = $routingComponent->handleToLowerCase($uri);
 
         $this->assertEquals($uri, $newUri);
@@ -58,8 +61,8 @@ class RoutingComponentTest extends UnitTestCase
         $routingComponent = new RoutingComponent();
 
         $camelCasePath = '/testPath/';
-        $uri = new Uri('http://dev.local' . $camelCasePath);
-        $newUri = $routingComponent->handleToLowerCase($uri);
+        $uri           = new Uri('http://dev.local' . $camelCasePath);
+        $newUri        = $routingComponent->handleToLowerCase($uri);
 
         $this->assertNotEquals($camelCasePath, $newUri->getPath());
         $this->assertEquals(strtolower($camelCasePath), $newUri->getPath());
@@ -72,11 +75,46 @@ class RoutingComponentTest extends UnitTestCase
     {
         $routingComponent = new RoutingComponent();
 
-        $uri = new Uri('http://dev.local/äß&/');
+        $uri    = new Uri('http://dev.local/äß&/');
         $newUri = $routingComponent->handleToLowerCase($uri);
         $newUri = $routingComponent->handleTrailingSlash($newUri);
 
         $this->assertEquals($uri, $newUri);
     }
 
+    /**
+     * @test
+     */
+    public function ifPathHasNoChangesDoNotRedirect()
+    {
+        $httpRequest = new Request([], [], [], []);
+        $httpResponse = new Response();
+        $componentContext = new ComponentContext($httpRequest, $httpResponse);
+
+        $oldUri = new Uri('http://dev.local/äß&/');
+        $newUri = new Uri('http://dev.local/äß&/');
+
+        $routingComponent = new RoutingComponent();
+        $redirect = $routingComponent->redirectIfNecessary($componentContext, $newUri, $oldUri->getPath());
+
+        $this->assertEquals(false, $redirect);
+    }
+
+    /**
+     * @test
+     */
+    public function ifPathHasChangesRedirect()
+    {
+        $httpRequest = new Request([], [], [], []);
+        $httpResponse = new Response();
+        $componentContext = new ComponentContext($httpRequest, $httpResponse);
+
+        $oldUri = new Uri('http://dev.local/teST');
+        $newUri = new Uri('http://dev.local/test/');
+
+        $routingComponent = new RoutingComponent();
+        $redirect = $routingComponent->redirectIfNecessary($componentContext, $newUri, $oldUri->getPath());
+
+        $this->assertEquals(true, $redirect);
+    }
 }

--- a/Tests/Unit/SlackServiceTest.php
+++ b/Tests/Unit/SlackServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace t3n\SEO\Routing\Tests\Unit;
+
+use Neos\Flow\Http\Uri;
+use Neos\Flow\Tests\UnitTestCase;
+use t3n\SEO\Routing\RoutingComponent;
+
+class RoutingComponentTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function uriWithSlashGetsNotModifiedForTrailingSlash()
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath/');
+        $newUri = $routingComponent->handleTrailingSlash($uri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithOutSlashGetsModifiedForTrailingSlash()
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath');
+        $newUri = $routingComponent->handleTrailingSlash($uri);
+
+        $this->assertStringEndsWith('/', (string)$newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithLoweredPathGetsNotModified()
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/testpath/');
+        $newUri = $routingComponent->handleToLowerCase($uri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithCamelCasePathGetsModifiedToLowereCase()
+    {
+        $routingComponent = new RoutingComponent();
+
+        $camelCasePath = '/testPath/';
+        $uri = new Uri('http://dev.local' . $camelCasePath);
+        $newUri = $routingComponent->handleToLowerCase($uri);
+
+        $this->assertNotEquals($camelCasePath, $newUri->getPath());
+        $this->assertEquals(strtolower($camelCasePath), $newUri->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function uriWithSpecialCharsDoesNotThrowAnException()
+    {
+        $routingComponent = new RoutingComponent();
+
+        $uri = new Uri('http://dev.local/äß&/');
+        $newUri = $routingComponent->handleToLowerCase($uri);
+        $newUri = $routingComponent->handleTrailingSlash($newUri);
+
+        $this->assertEquals($uri, $newUri);
+    }
+
+}

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -1,6 +1,18 @@
 {
   "name": "t3n/test-setup",
   "description": "Test setup for flow packages",
+  "repositories": [
+    {
+      "type": "git",
+      "url": "git@github.com:t3n/seo-routing.git"
+    },
+    {
+      "type": "path",
+      "url": "./seo-routing"
+    }
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "config": {
     "vendor-dir": "Packages/Libraries",
     "bin-dir": "bin"
@@ -8,24 +20,22 @@
   "require": {
     "neos/flow": "~5.2.0",
     "neos/buildessentials": "~5.2.0",
-    "t3n/seo-routing": "@dev",
-    "t3n/coding-standard": "~1.0.0"
+    "t3n/seo-routing": "@dev"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "3.3.2",
+    "t3n/coding-standard": "~1.0.0",
     "phpunit/phpunit": "~7.1",
     "mikey179/vfsstream": "~1.6"
-  },
-  "repositories": {
-    "srcPackage": {
-      "type": "path",
-      "url": "./seo-routing"
-    }
   },
   "scripts": {
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
     "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall"
+  },
+    "autoload": {
+      "psr-4": {
+      "t3n\\SEO\\Routing\\": "seo-routing/Classes/"
+    }
   }
 }

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -24,7 +24,8 @@
   },
   "require-dev": {
     "t3n/coding-standard": "~1.0.0",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~7.1",
+    "mikey179/vfsstream": "~1.6"
   },
   "scripts": {
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -23,7 +23,7 @@
     "t3n/seo-routing": "@dev"
   },
   "require-dev": {
-    "t3n/coding-standard": "~1.0.0"
+    "t3n/coding-standard": "~1.0.0",
     "phpunit/phpunit": "~7.1"
   },
   "scripts": {

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -20,7 +20,7 @@
   "require": {
     "neos/flow": "~5.2.0",
     "neos/buildessentials": "~5.2.0",
-    "t3n/seo-routing": "@dev",
+    "t3n/seo-routing": "@dev"
   },
   "require-dev": {
     "t3n/coding-standard": "~1.0.0"

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -33,5 +33,10 @@
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
     "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
     "code-style": "bin/phpcs neos-form"
+  },
+    "autoload": {
+      "psr-4": {
+      "t3n\\SEO\\Routing\\": "seo-routing/Classes/"
+    }
   }
 }

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -31,6 +31,6 @@
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
     "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
-    "code-style": "bin/phpcs neos-form",
+    "code-style": "bin/phpcs neos-form"
   }
 }

--- a/composer.json.ci
+++ b/composer.json.ci
@@ -1,6 +1,18 @@
 {
   "name": "t3n/test-setup",
   "description": "Test setup for flow packages",
+  "repositories": [
+    {
+      "type": "git",
+      "url": "git@github.com:t3n/seo-routing.git"
+    },
+    {
+      "type": "path",
+      "url": "./seo-routing"
+    }
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "config": {
     "vendor-dir": "Packages/Libraries",
     "bin-dir": "bin"
@@ -9,23 +21,16 @@
     "neos/flow": "~5.2.0",
     "neos/buildessentials": "~5.2.0",
     "t3n/seo-routing": "@dev",
-    "t3n/coding-standard": "~1.0.0"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "3.3.2",
-    "phpunit/phpunit": "~7.1",
-    "mikey179/vfsstream": "~1.6"
-  },
-  "repositories": {
-    "srcPackage": {
-      "type": "path",
-      "url": "./seo-routing"
-    }
+    "t3n/coding-standard": "~1.0.0"
+    "phpunit/phpunit": "~7.1"
   },
   "scripts": {
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
-    "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall"
+    "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
+    "code-style": "bin/phpcs neos-form",
   }
 }

--- a/unitTests.xml
+++ b/unitTests.xml
@@ -9,7 +9,7 @@
         timeoutForSmallTests="0">
     <testsuites>
         <testsuite name="seo-routing">
-            <directory>Tests</directory>
+            <directory>seo-routing/Tests/Unit</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/unitTests.xml
+++ b/unitTests.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutOutputDuringTests="true"
+        bootstrap="Build/BuildEssentials/PhpUnit/UnitTestBootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        timeoutForSmallTests="0">
+    <testsuites>
+        <testsuite name="seo-routing">
+            <directory>seo-routing/Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/unitTests.xml
+++ b/unitTests.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutOutputDuringTests="true"
+        bootstrap="Build/BuildEssentials/PhpUnit/UnitTestBootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        timeoutForSmallTests="0">
+    <testsuites>
+        <testsuite name="seo-routing">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Sometimes you want to allow urls like `t3n.de/camelCase`, which will automatically redirect to `t3n.de/camelcase`. This ensures that all backlinks/external links will return a valid page with a standardized path (lowerecased with trailing slash).