### PR TITLE
Adjust response instead of create a new one

### DIFF
--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -124,7 +124,7 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         $statusCode = array_key_exists('statusCode', $this->configuration) ? $this->configuration['statusCode'] : 301;
 
         $response = $componentContext->getHttpResponse()->withStatus($statusCode);
-        $response = $response->withAddedHeader('Location', (string)$uri);
+        $response = $response->withAddedHeader('Location', (string) $uri);
 
         $componentContext->replaceHttpResponse($response);
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);

--- a/Classes/RoutingComponent.php
+++ b/Classes/RoutingComponent.php
@@ -123,8 +123,8 @@ class RoutingComponent extends \Neos\Flow\Mvc\Routing\RoutingComponent
         //set default redirect statusCode if configuration is not set
         $statusCode = array_key_exists('statusCode', $this->configuration) ? $this->configuration['statusCode'] : 301;
 
-        /** @var ResponseInterface $response */
-        $response = new Response((int) $statusCode, ['Location' => (string) $uri]);
+        $response = $componentContext->getHttpResponse()->withStatus($statusCode);
+        $response = $response->withAddedHeader('Location', (string)$uri);
 
         $componentContext->replaceHttpResponse($response);
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);


### PR DESCRIPTION
With this change the response will hold all arguments and redirects if necessary - otherwise all arguments are lost.